### PR TITLE
Update to 25.0.4 / System & Apps Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN set -ex; \
 
 # install the PHP extensions we need
 # see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
-ENV PHP_MEMORY_LIMIT 2048M
+ENV PHP_MEMORY_LIMIT 3072M
 ENV PHP_UPLOAD_LIMIT 20480M
 RUN set -ex; \
     \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG PLATFORM
 # aarch64 or x86_64
 ARG ARCH
 
-RUN apt-get update && apt-get install -y wget libmagickcore-6.q16-6-extra postgresql-13 tini bash sudo ed \
+RUN apt-get update && apt-get install -y wget libmagickcore-6.q16-6-extra postgresql-13 tini bash sudo ed exiftool ffmpeg \
 && apt-get install -qq --no-install-recommends ca-certificates dirmngr
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.6.3/yq_linux_${PLATFORM}.tar.gz -O - |\
   tar xz && mv yq_linux_${PLATFORM} /usr/bin/yq
@@ -118,6 +118,8 @@ RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.save_comments=1'; \
         echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.jit=1255'; \
+        echo 'opcache.jit_buffer_size=128M'; \
     } > "${PHP_INI_DIR}/conf.d/opcache-recommended.ini"; \
     \
     echo 'apc.enable_cli=1' >> "${PHP_INI_DIR}/conf.d/docker-php-ext-apcu.ini"; \
@@ -143,7 +145,7 @@ RUN a2enmod headers rewrite remoteip ;\
     } > /etc/apache2/conf-available/remoteip.conf;\
     a2enconf remoteip
 
-ENV NEXTCLOUD_VERSION 25.0.3
+ENV NEXTCLOUD_VERSION 25.0.4
 
 RUN set -ex; \
     fetchDeps=" \
@@ -178,8 +180,9 @@ COPY docker/25/apache/entrypoint.sh /
 VOLUME /var/lib/postgresql/13
 VOLUME /etc/postgresql/13
 
-# Import Entrypoint and give permissions
+# Import Entrypoint and Actions scripts and give permissions
 ADD ./docker_entrypoint.sh /usr/local/bin/docker_entrypoint.sh
 ADD ./check-web.sh /usr/local/bin/check-web.sh
 ADD actions/reset-pass.sh /usr/local/bin/reset-pass.sh
+ADD actions/index-memories.sh /usr/local/bin/index-memories.sh
 RUN chmod a+x /usr/local/bin/*.sh

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -67,6 +67,22 @@ if [ -e "$FILE" ] ; then {
   sed -i 's/\#ServerName www\.example\.com.*/ServerName nextcloud.embassy\n        <IfModule mod_headers\.c>\n          Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains"\n        <\/IfModule>/' /etc/apache2/sites-enabled/000-default.conf
   sed -i "s/'overwrite\.cli\.url' => .*/'overwrite\.cli\.url' => 'https\:\/\/$LAN_ADDRESS'\,/" $FILE
 
+  # set additional config.php settings for Memories app
+  # see https://github.com/pulsejet/memories/wiki/Configuration and https://github.com/pulsejet/memories/wiki/File-Type-Support
+  # echo "
+  # 'preview_max_memory' => 2048,
+  # 'preview_max_filesize_image' => 256,
+  # 'enabledPreviewProviders' =>
+  #   array (
+  #     'OC\\Preview\\Image',
+  #     'OC\\Preview\\HEIC',
+  #     'OC\\Preview\\TIFF',
+  #     'OC\\Preview\\Movie',
+  #     'OC\\Preview\\MKV',
+  #     'OC\\Preview\\MP4',
+  #     'OC\\Preview\\AVI',
+  #   )," >> "$FILE"
+
   echo "Changing Permissions..."
   chown -R postgres:postgres $POSTGRES_DATADIR
   chown -R postgres:postgres $POSTGRES_CONFIG

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,11 +1,13 @@
 id: nextcloud 
 title: Nextcloud
-version: 25.0.3.3
+version: 25.0.4
 release-notes: |
-  * Support for LAN and Tor simultaneously
-  * Change default background jobs to cron (enables use of the RSS feed app "News")
-  * Added new action 'Restore Default Admin Password'
-  * Update to latest upstream - See [full changelog](https://nextcloud.com/changelog/) under Version 25.0.3
+  * Added new action 'Index Media for Memories App'
+    * Indexes photos and videos for your desired media folders
+    * Enables video transcoding and HLS
+  * Increase memory limit to accomodate indexing
+  * 
+  * Update to latest upstream - See [full changelog](https://nextcloud.com/changelog/) under Version 25.0.4
 license: AGPL-3.0
 wrapper-repo: https://github.com/Start9Labs/nextcloud-wrapper
 upstream-repo: https://github.com/nextcloud/docker
@@ -133,5 +135,17 @@ actions:
       inject: true
       args: []
       io-format: json
-      mounts:
-        main: /root
+  index-memories:
+    name: "Index Media for Memories App"
+    description: "Indexes all media for the Memories media app and enables video support and previews.  You MUST install the Memories app before running this Action."
+    warning: ~
+    allowed-statuses:
+      - running
+    implementation:
+      type: docker
+      image: main
+      system: false
+      entrypoint: index-memories.sh
+      inject: true
+      args: []
+      io-format: json

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -3,8 +3,6 @@ import { compat, matches, types as T } from "../deps.ts";
 export const migration: T.ExpectedExports.migration = compat.migrations
   .fromMapping(
     {
-      // 25.0.2 - initial release
-      //
       "25.0.3.3": {
         up: compat.migrations.updateConfig(
           async (config, effects) => {


### PR DESCRIPTION
## Server update
- [x] Update server to v25.0.4
## Memories (Photo app)
- [x] Up PHP memory limit to 3GB
- [ ] [Add deps and config](https://github.com/pulsejet/memories/wiki/Configuration) for Memories and NCDownloader
- [x] Create [Indexing Action for Memories](https://github.com/pulsejet/memories#-installation)
- [ ] Add support for more [file types](https://github.com/pulsejet/memories/wiki/File-Type-Support)
- [ ] New migration
## Backups
- [ ] New backups procedures with rsync? (eOS v0.3.4 dependent)