### PR TITLE
Fix 0.3.5x migration OOM on chmod

### DIFF
--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,8 +1,8 @@
 import { VersionGraph } from '@start9labs/start-sdk'
 import { v_31_0_13_0 } from './v31.0.13.0'
-import { v_32_0_7_0 } from './v32.0.7.0'
+import { v_32_0_7_1 } from './v32.0.7.1'
 
 export const versionGraph = VersionGraph.of({
-  current: v_32_0_7_0,
+  current: v_32_0_7_1,
   other: [v_31_0_13_0],
 })

--- a/startos/versions/v32.0.7.1.ts
+++ b/startos/versions/v32.0.7.1.ts
@@ -89,10 +89,6 @@ const migrateNextcloud = async (effects: T.Effects) => {
         [
           'find',
           NEXTCLOUD_PATH,
-          '-path',
-          `${NEXTCLOUD_PATH}/data`,
-          '-prune',
-          '-o',
           '-exec',
           'chmod',
           'ug+rw,o-rwx',

--- a/startos/versions/v32.0.7.1.ts
+++ b/startos/versions/v32.0.7.1.ts
@@ -85,21 +85,31 @@ const migrateNextcloud = async (effects: T.Effects) => {
     nextcloudMount,
     'upgrade-sub',
     async (sub) => {
-      await sub.execFail(['chmod', '-R', 'ug+rw', NEXTCLOUD_PATH], {
-        user: 'root',
-      })
+      await sub.execFail(
+        [
+          'find',
+          NEXTCLOUD_PATH,
+          '-path',
+          `${NEXTCLOUD_PATH}/data`,
+          '-prune',
+          '-o',
+          '-exec',
+          'chmod',
+          'ug+rw,o-rwx',
+          '{}',
+          '+',
+        ],
+        { user: 'root' },
+      )
       await sub.execFail(['chmod', 'u+x', `${NEXTCLOUD_PATH}/occ`], {
-        user: 'root',
-      })
-      await sub.execFail(['chmod', '-R', 'o-rwx', NEXTCLOUD_PATH], {
         user: 'root',
       })
     },
   )
 }
 
-export const v_32_0_7_0 = VersionInfo.of({
-  version: '32.0.7:0',
+export const v_32_0_7_1 = VersionInfo.of({
+  version: '32.0.7:1',
   releaseNotes: {
     en_US: 'Update Nextcloud to 32.0.7',
     es_ES: 'Actualización de Nextcloud a 32.0.7',


### PR DESCRIPTION
## Summary

- Users updating from 0.3.5.1 to 32.0.7:0 hit a SIGKILL on `chmod -R` during migration, failing the install
- **Root cause:** `migrateNextcloud` ran `chmod -R` over all of `/var/www/html`, including `/var/www/html/data` (user files). On installations with large data directories, the process was OOM-killed
- **Fix:** Use `find -prune` to skip the `data/` directory. User data files were created by the `www-data` php-fpm process in 0.3.5.1 with standard permissions, and the 0.4.0 startup `chown` oneshot already handles ownership. The chmod is only needed for the app files, whose group changes from `root` (upstream Docker entrypoint) to `www-data` (0.4.0 setup)
- Also combines the two recursive chmod passes (`ug+rw` and `o-rwx`) into a single `find -exec chmod ug+rw,o-rwx`
- Bumps version to `32.0.7:1`

## Test plan

- [ ] Update from 0.3.5.1 with a large data directory (many user files) — migration should complete without OOM
- [ ] Verify Nextcloud app files have correct permissions after migration (`ug+rw,o-rwx`)
- [ ] Verify user data files are still accessible after migration
- [ ] Fresh install still works (migration is skipped, no config.yaml present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)